### PR TITLE
Properly escape song query if it's a URL

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -68,7 +68,7 @@ function escapeUrl(str) {
 function getSongAsObject(song) {
 	let result = {
 		url: escapeUrl(song.url),
-		query: escapeDiscord(song.query),
+		query: isURL(song.query) ? escapeUrl(song.query) : escapeDiscord(song.query),
 		thumbnail: escapeUrl(song.thumbnail),
 		duration: escapeDiscord(song.duration),
 		author: escapeDiscord(song.author),


### PR DESCRIPTION
The URL would be escaped using the escapeDiscord function, which would add unnecessary slashes in the URL, rendering it invalid.
Example: https://i.imgur.com/HHsTS1g.png